### PR TITLE
Adds Icon parameter to Weather

### DIFF
--- a/openweathermap.go
+++ b/openweathermap.go
@@ -30,6 +30,7 @@ type Weather struct {
 	Id int `json:"id"`
 	Main string `json:"main"`
 	Description string `json:"description"`
+	Icon string `json:"icon"`
 }
 
 type Wind struct {


### PR DESCRIPTION
This adds the `icon` value of a weather result to the `Weather` struct.

I admit that I did not do much more checking if additional fields are missing, but this one was missing and I needed it, hence the pull request.